### PR TITLE
fix(am2302_rmt): correct required components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "src/am2302_rmt.c"
                        INCLUDE_DIRS "include"
-                       PRIV_REQUIRES driver)
+                       REQUIRES driver esp_driver_rmt)


### PR DESCRIPTION
## Problem
When I put the code that uses this component in an component itself (i.e. not in the main component), I get an error, because the `esp_driver_rmt` component is not listed in the CMakeLists.txt:
```
Compilation failed because am2302_rmt.h (in "suda-morris__am2302_rmt" component) includes driver/rmt_types.h, provided by esp_driver_rmt component(s).
However, esp_driver_rmt component(s) is not in the requirements list of "suda-morris__am2302_rmt".
To fix this, add esp_driver_rmt to REQUIRES list of idf_component_register call in /home/arco/programming/esp/meset/managed_components/suda-morris__am2302_rmt/CMakeLists.txt.
```

## Fix description
Previously, only the driver component was privately required. However, the esp_driver_rmt component is used as well and should therefore also be required. Since both components are used in the public header file, both components should be publicly required. This commit updates the REQUIRES list to fix this.